### PR TITLE
build "printinfo" executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 # -DHACC_IO_DISABLE_READ to build version that only creates a checkpoint
 # -DHACC_IO_DISABLE_WRITE to build version that only reads a checkpoint
 
-HACC_EXE = hacc_io hacc_io_write hacc_io_read hacc_open_close 
+HACC_EXE = hacc_io hacc_io_write hacc_io_read hacc_open_close hacc_printinfo
 CXXFLAGS =  -g -O3 -DGLEAN_PRINT_PERROR -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -Wall
 
 ### Targets - do file-per-process by default
@@ -28,11 +28,17 @@ hacc_io_read: restartio_glean.o testhacc_io_read.o
 hacc_open_close: restartio_glean.o testhacc_open_close.o
 	$(CXX) $(LDFLAGS) $^ $(LOADLIBES) $(LDLIBS) -o $@
 
+hacc_printinfo: restartio_glean.o testhacc_printinfo.o
+	$(CXX) $(LDFLAGS) $^ $(LOADLIBES) $(LDLIBS) -o $@
+
 testhacc_io_read.o: testhacc_io.cc always
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -DHACC_IO_DISABLE_WRITE -c $< -o $@
 
 testhacc_io_write.o: testhacc_io.cc always
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -DHACC_IO_DISABLE_READ -c $< -o $@
+
+testhacc_printinfo.o: testhacc_printinfo.cc always
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
 
 clean:
 	-rm -f *.a *.o $(HACC_EXE)

--- a/restartio_glean.cc
+++ b/restartio_glean.cc
@@ -884,7 +884,7 @@ void RestartIO_GLEAN::PrintIOCoordInfo (void)
         switch (m_fileDist)
         {
             case GLEAN_FILE_PER_RANK:
-                cout << " Mode: Single Shared File" << endl;
+                cout << " Mode: File per Rank" << endl;
                 break;
             
             #ifdef __bgq__


### PR DESCRIPTION
Two changes were made:
1) The Makefile was augmented to also build the **hacc_printinfo** executable
2) The respective routine was printing the wrong mode string for the preprocessor flag **HACC_IO_FILE_PER_PROCESS**